### PR TITLE
Add Julius Krumbiegel's blog to Going Further

### DIFF
--- a/further/index.md
+++ b/further/index.md
@@ -35,6 +35,7 @@ title = "Going further"
 * [Bogumił Kamiński](https://bkamins.github.io/)
 * [Katharine Hyatt](https://kshyatt.github.io/)
 * [Frames Catherine White](https://www.oxinabox.net/blog.html)
+* [Julius Krumbiegel](https://jkrumbiegel.com/)
 * [Invenia](https://invenia.github.io/blog/)
 
 ## Videos


### PR DESCRIPTION
I tried to add a link to this blog post ([Pkg.jl and Julia Environments for Beginners](https://jkrumbiegel.com/pages/2022-08-26-pkg-introduction/)) in the Writing section but was told non-official resources should be in Going Further instead. I think this post in-particular is required reading for new users, since no other resource I know of currently explains environments this understandably with detail. Not sure if there is a way to highlight that post of the blog in particular that would look consistent?

