### PR TITLE
Add sidebar table of contents

### DIFF
--- a/_css/poole_hyde.css
+++ b/_css/poole_hyde.css
@@ -304,6 +304,21 @@ a.sidebar-nav-item:focus {
   font-weight: bold;
 }
 
+/* Hide submenu by default */
+.menu-list-child-list {
+  display: none;
+}
+
+/* Show submenu when parent item has 'active' class */
+.sidebar-nav-item.active + .menu-list-child-list {
+  display: block;
+}
+
+.menu-list-link {
+  color: rgba(255, 255, 255, 0.5)  !important;
+  font-size: var(--small);
+}
+
 /* Sticky sidebar
  *
  * Add the `sidebar-sticky` class to the sidebar's container to affix it the

--- a/_layout/sidebar.html
+++ b/_layout/sidebar.html
@@ -8,11 +8,67 @@
       </div>
     </div>
     <nav class="sidebar-nav">
-      <a class="sidebar-nav-item {{ispage index.html}}active{{end}}" href="/">Home</a>
+      <!-- HOME -->
+      <a class="sidebar-nav-item {{ispage index.html}}active{{end}}" href="/">Home</a>			  
+      <ul class="menu-list-child-list {{ispage index.html}}active{{end}}">
+        <li class="menu-list-item"><a href="/#goals" class="menu-list-link">• Goals</a>
+        <li class="menu-list-item"><a href="/#contents" class="menu-list-link">• Contents</a>
+        <li class="menu-list-item"><a href="/#before_you_start" class="menu-list-link">• Before you start</a>
+      </ul>
+      <!-- WRITTING -->
       <a class="sidebar-nav-item {{ispage /writing/*}}active{{end}}" href="/writing/">Writing</a>
+        <ul class="menu-list-child-list {{ispage /writing/*}}active{{end}}">
+          <li class="menu-list-item"><a href="/writing/#getting_help" class="menu-list-link">• Getting help</a>
+          <li class="menu-list-item"><a href="/writing/#installation" class="menu-list-link">• Installation</a>
+          <li class="menu-list-item"><a href="/writing/#repl" class="menu-list-link">• REPL</a>
+          <li class="menu-list-item"><a href="/writing/#editor" class="menu-list-link">• Editor</a>
+          <li class="menu-list-item"><a href="/writing/#running_code" class="menu-list-link">• Running code</a>
+          <li class="menu-list-item"><a href="/writing/#notebooks" class="menu-list-link">• Notebooks</a>
+          <li class="menu-list-item"><a href="/writing/#local_packages" class="menu-list-link">• Local packages</a>
+          <li class="menu-list-item"><a href="/writing/#development_workflow" class="menu-list-link">• Development workflow</a>
+          <li class="menu-list-item"><a href="/writing/#configuration" class="menu-list-link">• Configuration</a>
+          <li class="menu-list-item"><a href="/writing/#interactivity" class="menu-list-link">• Interactivity</a>
+          <li class="menu-list-item"><a href="/writing/#logging" class="menu-list-link">• Logging</a>
+          <li class="menu-list-item"><a href="/writing/#debugging" class="menu-list-link">• Debugging</a>
+        </ul>
+      <!-- SHARING -->
       <a class="sidebar-nav-item {{ispage /sharing/*}}active{{end}}" href="/sharing/">Sharing</a>
+      <ul class="menu-list-child-list {{ispage /sharing/*}}active{{end}}">
+        <li class="menu-list-item"><a href="/sharing/#setup" class="menu-list-link">• Setup</a>
+        <li class="menu-list-item"><a href="/sharing/#github_actions" class="menu-list-link">• GitHub Actions</a>
+        <li class="menu-list-item"><a href="/sharing/#testing" class="menu-list-link">• Testing</a>
+        <li class="menu-list-item"><a href="/sharing/#style" class="menu-list-link">• Style</a>
+        <li class="menu-list-item"><a href="/sharing/#code_quality" class="menu-list-link">• Code quality</a>
+        <li class="menu-list-item"><a href="/sharing/#documentation" class="menu-list-link">• Documentation</a>
+        <li class="menu-list-item"><a href="/sharing/#literate_programming" class="menu-list-link">• Literate programming</a>
+        <li class="menu-list-item"><a href="/sharing/#versions_and_registration" class="menu-list-link">• Versions and registration</a>
+        <li class="menu-list-item"><a href="/sharing/#reproducibility" class="menu-list-link">• Reproducibility</a>
+        <li class="menu-list-item"><a href="/sharing/#interoperability" class="menu-list-link">• Interoperability</a>
+        <li class="menu-list-item"><a href="/sharing/#collaboration" class="menu-list-link">• Collaboration</a>
+      </ul>
+      <!-- OPTIMIZING -->
       <a class="sidebar-nav-item {{ispage /optimizing/*}}active{{end}}" href="/optimizing/">Optimizing</a>
+      <ul class="menu-list-child-list {{ispage /optimizing/*}}active{{end}}">
+        <li class="menu-list-item"><a href="/optimizing/#principles" class="menu-list-link">• Principles</a>
+        <li class="menu-list-item"><a href="/optimizing/#measurements" class="menu-list-link">• Measurements</a>
+        <li class="menu-list-item"><a href="/optimizing/#benchmark_suites" class="menu-list-link">• Benchmark suites</a>
+        <li class="menu-list-item"><a href="/optimizing/#profiling" class="menu-list-link">• Profiling</a>
+        <li class="menu-list-item"><a href="/optimizing/#type_stability" class="menu-list-link">• Type stability</a>
+        <li class="menu-list-item"><a href="/optimizing/#memory_management" class="menu-list-link">• Memory management</a>
+        <li class="menu-list-item"><a href="/optimizing/#precompilation" class="menu-list-link">• Precompilation</a>
+        <li class="menu-list-item"><a href="/optimizing/#parallelism" class="menu-list-link">• Parallelism</a>
+        <li class="menu-list-item"><a href="/optimizing/#simd_/_gpu" class="menu-list-link">• SIMD / GPU</a>
+        <li class="menu-list-item"><a href="/optimizing/#efficient_types" class="menu-list-link">• Efficient types</a>
+      </ul>
+      <!-- GOING FURTHER -->
       <a class="sidebar-nav-item {{ispage /further/*}}active{{end}}" href="/further/">Going further</a>
+      <ul class="menu-list-child-list {{ispage /further/*}}active{{end}}">
+        <li class="menu-list-item"><a href="/further/#official" class="menu-list-link">• Official</a>
+        <li class="menu-list-item"><a href="/further/#tutorials" class="menu-list-link">• Tutorials</a>
+        <li class="menu-list-item"><a href="/further/#blogs" class="menu-list-link">• Blogs</a>
+        <li class="menu-list-item"><a href="/further/#videos" class="menu-list-link">• Videos</a>
+        <li class="menu-list-item"><a href="/further/#lore" class="menu-list-link">• Lore</a>
+      </ul>
     </nav>
     <p>&copy; {{fill author}}.</p>
   </div>


### PR DESCRIPTION
A table of contents in the sidebar aids navigation in longer pages. The table only shows up for the currently active site.

The only downside is that, since the sidebar is html-based, every subsection must be manually inserted in the sidebar html.

**Before**
![スクリーンショット 2024-05-30 15 46 51](https://github.com/modernjuliaworkflows/modernjuliaworkflows.github.io/assets/48489827/390c0a42-aee7-4797-83c1-dc71b698283b)

**After**
![スクリーンショット 2024-05-30 15 47 34](https://github.com/modernjuliaworkflows/modernjuliaworkflows.github.io/assets/48489827/fb294578-9379-4669-bc46-4d0263126d52)
