### PR TITLE
Introduction of new Markdown section in Writing

### DIFF
--- a/writing/index.md
+++ b/writing/index.md
@@ -264,12 +264,10 @@ julia> Pluto.run()
 \tldr{Markdown is also a good fit for literate programming, and Quarto is an alternative to notebooks.}
 
 [Markdown](https://www.markdownguide.org/) is a markup language used to add formatting elements to plaintext text files.
-For example, to bold text one encapsulates words with double asterisks: `**bold text**` -> **bold text**.
-Markdown files can be opened by any text editor, such as VSCode, and are particularly useful when the file itself is not the final product.
 
 ### Plain Text Markdown
 Plain text markdown files, which have the `.md` extension, are not used for interactive programming, meaning one cannot run code written in the file.
-Plain text markdown files are usually rendered into something else, such as but not limited to documents (e.g., PDF, Word), websites, presentations, and even books.
+As a result, plain text markdown files are usually rendered into a final product by other software.
 
 This is an example of a plain text markdown file:
 
@@ -290,37 +288,40 @@ println("hello world")
 [Quarto](https://quarto.org/) "is an open-source scientific and technical publishing system."
 Quarto makes a plain text markdown file (`.md`) alternative called Quarto markdown file (`.qmd`).
 
-Quarto markdown files like plain text markdown files also integrate with editors, such as VSCode, and can be rendered into various output formats, such as websites.
+Quarto markdown files like plain text markdown files also integrate with editors, such as VSCode.
 
 \vscode{
 
-Install the Quarto extension for a streamlined experience.
+Install the Quarto [extension](https://marketplace.visualstudio.com/items?itemName=quarto.quarto) for a streamlined experience.
 
 }
 
 Unlike plain text markdown files, Quarto markdown files have executable code chunks.
-These code chunks provide a functionality similar to notebooks, which makes Quarto markdown files an alternative to writing code in notebooks.
-Additionally, Quarto markdown files give users additional control over output and styling via YAML headers.
+These code chunks provide a functionality similar to notebooks, thus Quarto markdown files are an alternative to notebooks.
+Additionally, Quarto markdown files give users additional control over output and styling via the YAML header at the top of the `.qmd` file.
 
-Below is a revised markdown example using Quarto.
-If this file were opened in an editor such as VSCode one could execute the `println("hello world")` Julia code and view the output.
-Also, notice the YAML header at the top of the page that defines the document's title and specifies to make the code chunks invisible via the `echo: false` command.
-When `echo` is set to `false` the output of the code chunks will be displayed but the code itself will be hidden.
-
-Last, as of Quarto version 1.5, Julia programmers have the option to use a native Julia engine to execute code - previously IJulia.jl was the only Julia engine.
-The primary difference betweens IJulia.jl and the native Julia engine is that the native Julia engine does not depend on Python and can utilize local environments.
+As of Quarto version 1.5, users can choose from two Julia engines to execute code - a native Julia engine and IJulia.jl.
+The primary difference between the native Julia engine and IJulia.jl is that the native Julia engine does not depend on Python and can utilize local environments.
+For this reason it's recommended to start with the native Julia engine.
 Learn more about the native Julia engine in Quarto's [documentation](https://quarto.org/docs/blog/posts/2024-07-11-1.5-release/#native-julia-engine).
-To use the native Julia engine set `engine` equal to `julia` in the YAML header of the Quarto markdown file as seen below.
+
+Below is an example of a Quarto markdown file.
 
 ````quarto
 ---
 title: "My document"
 format:
+  # renders a HTML document
   html:
+    # table of contents
     toc: true
 execute:
+  # makes code chunks invisible in the output
+  # code output is still visible though
   echo: false
+  # hides warnings in the output
   warning: false
+# native julia engine
 engine: julia
 ---
 
@@ -329,6 +330,8 @@ engine: julia
 ## Section Header
 
 Below is an executable code chunk.
+
+If this file were opened in an editor such as VSCode one could execute the `println("hello world")` Julia code and view the output, like in a notebook.
 
 ```{{julia}}
 println("hello world")

--- a/writing/index.md
+++ b/writing/index.md
@@ -259,6 +259,49 @@ julia> using Pluto
 julia> Pluto.run()
 ```
 
+## Markdown
+
+\tldr{Markdown is also a good fit for literate programming.}
+
+[Markdown](https://www.markdownguide.org/) can be an alternative to writing code in notebooks (such as Jupyter), and is particularly useful when the file itself is not the final product, which is a key element of literate programming. Markdown is a markup language used to add formatting elements to plaintext text files, for example to bold text one would write `**bold words**`. Markdown is portable so it can be opened by any text editor, such as VSCode.
+
+### Plain Text Markdown
+Plain text markdown files, which have the `.md` extension, are not used for interactive programming, meaning one cannot run code written in the file.
+Plain text markdown files are not an alternative to writing code in notebooks.
+Plain text markdown files are usually rendered into something else, such as but not limited to documents (e.g., PDF, Word), websites, presentations, and even books.
+
+This is an example of a plain text markdown file:
+
+````markdown
+# Title
+
+## Section Header
+
+This is example text.
+
+```julia
+println("hello world")
+```
+````
+
+### Quarto
+
+An alternative to `.md` markdown files are Quarto markdown files (`.qmd`).
+[Quarto](https://quarto.org/) is an open-source scientific and technical publishing system.
+
+Unlike plain text `.md` markdown files, Quarto markdown files offer several advantages.
+In regards to writing code, the primary advantage is executable code cells/ chunks.
+In this fashion, Quarto markdown files are an alternative to writing code in notebooks (such as Jupyter).
+Quarto markdown files can also be rendered into the aforementioned output formats.
+
+If the above example of a plain text markdown file were instead a Quarto markdown file, then within the editor, VSCode for example, one would be able to execute the `println("hello world")` Julia code and view the output.
+
+\vscode{
+
+Install the Quarto extension for a streamlined experience.
+
+}
+
 ## Environments
 
 \tldr{Activate a local environment for each project with `]activate path`. Its details are stored in `Project.toml` and `Manifest.toml`.}

--- a/writing/index.md
+++ b/writing/index.md
@@ -261,13 +261,14 @@ julia> Pluto.run()
 
 ## Markdown
 
-\tldr{Markdown is also a good fit for literate programming.}
+\tldr{Markdown is also a good fit for literate programming, and Quarto is an alternative to notebooks.}
 
-[Markdown](https://www.markdownguide.org/) can be an alternative to writing code in notebooks (such as Jupyter), and is particularly useful when the file itself is not the final product, which is a key element of literate programming. Markdown is a markup language used to add formatting elements to plaintext text files, for example to bold text one would write `**bold words**`. Markdown is portable so it can be opened by any text editor, such as VSCode.
+[Markdown](https://www.markdownguide.org/) is a markup language used to add formatting elements to plaintext text files.
+For example, to bold text one encapsulates words with double asterisks: `**bold text**` -> **bold text**.
+Markdown files can be opened by any text editor, such as VSCode, and are particularly useful when the file itself is not the final product.
 
 ### Plain Text Markdown
 Plain text markdown files, which have the `.md` extension, are not used for interactive programming, meaning one cannot run code written in the file.
-Plain text markdown files are not an alternative to writing code in notebooks.
 Plain text markdown files are usually rendered into something else, such as but not limited to documents (e.g., PDF, Word), websites, presentations, and even books.
 
 This is an example of a plain text markdown file:
@@ -286,21 +287,53 @@ println("hello world")
 
 ### Quarto
 
-An alternative to `.md` markdown files are Quarto markdown files (`.qmd`).
-[Quarto](https://quarto.org/) is an open-source scientific and technical publishing system.
+[Quarto](https://quarto.org/) "is an open-source scientific and technical publishing system."
+Quarto makes a plain text markdown file (`.md`) alternative called Quarto markdown file (`.qmd`).
 
-Unlike plain text `.md` markdown files, Quarto markdown files offer several advantages.
-In regards to writing code, the primary advantage is executable code cells/ chunks.
-In this fashion, Quarto markdown files are an alternative to writing code in notebooks (such as Jupyter).
-Quarto markdown files can also be rendered into the aforementioned output formats.
-
-If the above example of a plain text markdown file were instead a Quarto markdown file, then within the editor, VSCode for example, one would be able to execute the `println("hello world")` Julia code and view the output.
+Quarto markdown files like plain text markdown files also integrate with editors, such as VSCode, and can be rendered into various output formats, such as websites.
 
 \vscode{
 
 Install the Quarto extension for a streamlined experience.
 
 }
+
+Unlike plain text markdown files, Quarto markdown files have executable code chunks.
+These code chunks provide a functionality similar to notebooks, which makes Quarto markdown files an alternative to writing code in notebooks.
+Additionally, Quarto markdown files give users additional control over output and styling via YAML headers.
+
+Below is a revised markdown example using Quarto.
+If this file were opened in an editor such as VSCode one could execute the `println("hello world")` Julia code and view the output.
+Also, notice the YAML header at the top of the page that defines the document's title and specifies to make the code chunks invisible via the `echo: false` command.
+When `echo` is set to `false` the output of the code chunks will be displayed but the code itself will be hidden.
+
+Last, as of Quarto version 1.5, Julia programmers have the option to use a native Julia engine to execute code - previously IJulia.jl was the only Julia engine.
+The primary difference betweens IJulia.jl and the native Julia engine is that the native Julia engine does not depend on Python and can utilize local environments.
+Learn more about the native Julia engine in Quarto's [documentation](https://quarto.org/docs/blog/posts/2024-07-11-1.5-release/#native-julia-engine).
+To use the native Julia engine set `engine` equal to `julia` in the YAML header of the Quarto markdown file as seen below.
+
+````quarto
+---
+title: "My document"
+format:
+  html:
+    toc: true
+execute:
+  echo: false
+  warning: false
+engine: julia
+---
+
+# Title
+
+## Section Header
+
+Below is an executable code chunk.
+
+```{{julia}}
+println("hello world")
+```
+````
 
 ## Environments
 


### PR DESCRIPTION
Hi, all.

I am submitting a proposed revision to the Writing section based on issue #118.

This PR introduces a new sub-section in Writing called Markdown that is comprised of two parts:

- Plain Text Markdown
- Quarto

A new section was needed as markdown files (Quarto included) are not typically the final product - unlike notebooks which are commonly standalone products.