### PR TITLE
Add mention of StatProfilerHTML.jl for sharing profiles

### DIFF
--- a/optimizing/index.md
+++ b/optimizing/index.md
@@ -144,6 +144,8 @@ using ProfileView
 
 To integrate profile visualisations into environments like Jupyter and Pluto, use [ProfileSVG.jl](https://github.com/kimikage/ProfileSVG.jl) or [ProfileCanvas.jl](https://github.com/pfitzseb/ProfileCanvas.jl), whose outputs can be embedded into a notebook.
 
+For sharing profiles with others (e.g., on Slack or Discourse), [StatProfilerHTML.jl](https://github.com/tkluck/StatProfilerHTML.jl) is particularly useful as it generates self-contained HTML files that can be zipped and shared, allowing others to inspect the profiling results interactively without needing Julia installed.
+
 No matter which tool you use, if your code is too fast to collect samples, you may need to run it multiple times in a loop.
 
 \advanced{


### PR DESCRIPTION
## Summary
- Added mention of StatProfilerHTML.jl in the profiling visualization tools section
- Positioned after the paragraph about ProfileSVG.jl and ProfileCanvas.jl
- Highlights its usefulness for sharing profiles as zip files on platforms like Slack or Discourse

## Description
This PR adds a brief mention of [StatProfilerHTML.jl](https://github.com/tkluck/StatProfilerHTML.jl) to the profiling section of the Modern Julia Workflows documentation. 

StatProfilerHTML.jl is particularly valuable for collaborative workflows as it generates self-contained HTML files that can be zipped and shared with others. This allows team members to inspect profiling results interactively without needing Julia installed, making it ideal for sharing performance analysis on platforms like Slack or Discourse.

The addition fits naturally in the existing flow of profiling visualization tools, complementing the other tools mentioned (ProfileView.jl, PProf.jl, ProfileSVG.jl, ProfileCanvas.jl) by addressing the specific use case of sharing profiles with others.

## Test plan
- [x] Verified markdown formatting is correct
- [x] Checked that the link to StatProfilerHTML.jl repository is valid
- [x] Ensured the addition flows naturally with the existing content

🤖 Generated with [Claude Code](https://claude.ai/code)